### PR TITLE
Don't skip first stopped container.

### DIFF
--- a/_docker
+++ b/_docker
@@ -9,7 +9,7 @@
 #
 
 __parse_docker_list() {
-    sed -e '1d' -e 's/[ ]\{2,\}/|/g' -e 's/ \([hdwm]\)\(inutes\|ays\|ours\|eeks\)/\1/' | awk ' BEGIN {FS="|"} { printf("%s:%7s, %s\n", $1, $4, $2)}'
+    sed -e '/^ID/d' -e 's/[ ]\{2,\}/|/g' -e 's/ \([hdwm]\)\(inutes\|ays\|ours\|eeks\)/\1/' | awk ' BEGIN {FS="|"} { printf("%s:%7s, %s\n", $1, $4, $2)}'
 }
 
 __docker_stoppedcontainers() {


### PR DESCRIPTION
Stopped containers are filtered with the word `Exit`. Therefore, the
header line of `docker ps` is not present anymore. When we remove the
first line, we remove in fact the first stopped container. Replace
this by removing any line which starts with `ID`.
