### PR TITLE
minior fix to ignore updated container list header

### DIFF
--- a/_docker
+++ b/_docker
@@ -9,7 +9,7 @@
 #
 
 __parse_docker_list() {
-    sed -e '/^ID/d' -e 's/[ ]\{2,\}/|/g' -e 's/ \([hdwm]\)\(inutes\|ays\|ours\|eeks\)/\1/' | awk ' BEGIN {FS="|"} { printf("%s:%7s, %s\n", $1, $4, $2)}'
+    sed -e '/^CONTAINER ID/d' -e 's/[ ]\{2,\}/|/g' -e 's/ \([hdwm]\)\(inutes\|ays\|ours\|eeks\)/\1/' | awk ' BEGIN {FS="|"} { printf("%s:%7s, %s\n", $1, $4, $2)}'
 }
 
 __docker_stoppedcontainers() {


### PR DESCRIPTION
This will make sure the header dose not appear in the list of containers.
I think this was changed in a recently docker update.
