### PR TITLE
Handle container names

### DIFF
--- a/_docker
+++ b/_docker
@@ -9,13 +9,18 @@
 #
 
 __parse_docker_list() {
-    sed -e '/^ID/d' -e 's/[ ]\{2,\}/|/g' -e 's/ \([hdwm]\)\(inutes\|ays\|ours\|eeks\)/\1/' | awk ' BEGIN {FS="|"} { printf("%s:%7s, %s\n", $1, $4, $2)}'
+    sed -e '1d' \
+        -e 's/[ ]\{2,\}/|/g' \
+        -e 's/ \([hdwm]\)\(inutes\|ays\|ours\|eeks\)/\1/' | \
+        awk 'BEGIN {FS="|"}
+           '"$1"' { printf("%s:%7s, %s\n", $1, $4, $2) }
+           '"$1"' { if ($7 != "") printf("%s:%7s, %s\n", $7, $4, $2) }'
 }
 
 __docker_stoppedcontainers() {
     local expl
     declare -a stoppedcontainers 
-    stoppedcontainers=(${(f)"$(docker ps -a | grep --color=never 'Exit' |  __parse_docker_list )"})
+    stoppedcontainers=(${(f)"$(docker ps -a |  __parse_docker_list '($5 ~ /^Exit/)')"})
     _describe -t containers-stopped "Stopped Containers" stoppedcontainers 
 }
 
@@ -195,6 +200,7 @@ __docker_subcommand () {
                 '-h=-[Container host name]:hostname:_hosts' \
                 '-i[Keep stdin open even if not attached]' \
                 '-m=-[Memory limit (in bytes)]:limit: ' \
+                '-name=-[Container name]:name: ' \
                 '*-p=-[Expose a container''s port to the host]:port:_ports' \
                 '-t=-[Allocate a pseudo-tty]:toggle:(true false)' \
                 '-u=-[Username or UID]:user:_users' \


### PR DESCRIPTION
Since 0.6.5, it is possible to give names to running containers. We
support them when listing running and stopped containers as well as the
appropriate completion for `docker run -name=`.
