### PR TITLE
Add support for `docker run -link`

### DIFF
--- a/_docker
+++ b/_docker
@@ -214,6 +214,7 @@ __docker_subcommand () {
                 '-entrypoint=-[Overwrite the default entrypoint of the image]:entry point: ' \
                 '-h=-[Container host name]:hostname:_hosts' \
                 '-i[Keep stdin open even if not attached]' \
+                '-link=-[Link to another container]:container:__docker_runningcontainers' \
                 '-m=-[Memory limit (in bytes)]:limit: ' \
                 '-name=-[Container name]:name: ' \
                 '*-p=-[Expose a container''s port to the host]:port:_ports' \


### PR DESCRIPTION
This is not complete since the correct syntax is "container:alias", but
I don't know to teach zsh to do a partial completion, since we cannot
complete the alias part.
