### PR TITLE
Short options without equals sign

### DIFF
--- a/_docker
+++ b/_docker
@@ -179,13 +179,13 @@ __docker_subcommand () {
                 '--no-cache[Do not use cache when building the image]' \
                 '-q[Suppress verbose build output]' \
                 '--rm[Remove intermediate containers after a successful build]' \
-                '-t=-:repository:__docker_repositories_with_tags' \
+                '-t:repository:__docker_repositories_with_tags' \
                 ':path or URL:_directories'
             ;;
         (commit)
             _arguments \
                 '--author=-[Author]:author: ' \
-                '-m=-[Commit message]:message: ' \
+                '-m[Commit message]:message: ' \
                 '--run=-[Configuration automatically applied when the image is run]:configuration: ' \
                 ':container:__docker_containers' \
                 ':repository:__docker_repositories_with_tags'
@@ -251,9 +251,9 @@ __docker_subcommand () {
             ;;
         (login)
             _arguments \
-                '-e=-[Email]:email: ' \
-                '-p=-[Password]:password: ' \
-                '-u=-[Username]:username: ' \
+                '-e[Email]:email: ' \
+                '-p[Password]:password: ' \
+                '-u[Username]:username: ' \
                 ':server: '
             ;;
         (logs)
@@ -283,7 +283,7 @@ __docker_subcommand () {
                 '*:images:__docker_images'
             ;;
         (restart|stop)
-            _arguments '-t=-[Number of seconds to try to stop for before killing the container]:seconds to before killing:(1 5 10 30 60)' \
+            _arguments '-t[Number of seconds to try to stop for before killing the container]:seconds to before killing:(1 5 10 30 60)' \
                 '*:containers:__docker_runningcontainers'
             ;;
         (top)
@@ -302,7 +302,7 @@ __docker_subcommand () {
                 '-a[Show all containers]' \
                 '--before=-[Show only container created before...]:containers:__docker_containers' \
                 '-l[Show only the latest created container]' \
-                '-n=-[Show n last created containers, include non-running one]:n:(1 5 10 25 50)' \
+                '-n[Show n last created containers, include non-running one]:n:(1 5 10 25 50)' \
                 '--no-trunc[Do not truncate output]' \
                 '-q[Only show numeric IDs]' \
                 '-s[Display sizes]' \
@@ -318,28 +318,28 @@ __docker_subcommand () {
             _arguments \
                 '-P[Publish all exposed ports to the host]' \
                 '-a[Attach to stdin, stdout or stderr]' \
-                '-c=-[CPU shares (relative weight)]:CPU shares:(0 10 100 200 500 800 1000)' \
+                '-c[CPU shares (relative weight)]:CPU shares:(0 10 100 200 500 800 1000)' \
                 '--cidfile=-[Write the container ID to the file]:CID file:_files' \
                 '-d[Detached mode: leave the container running in the background]' \
                 '*--dns=-[Set custom dns servers]:dns server: ' \
-                '*-e=-[Set environment variables]:environment variable: ' \
+                '*-e[Set environment variables]:environment variable: ' \
                 '--entrypoint=-[Overwrite the default entrypoint of the image]:entry point: ' \
                 '*--expose=-[Expose a port from the container without publishing it]: ' \
-                '-h=-[Container host name]:hostname:_hosts' \
+                '-h[Container host name]:hostname:_hosts' \
                 '-i[Keep stdin open even if not attached]' \
                 '--link=-[Add link to another container]:link:->link' \
                 '--lxc-conf=-[Add custom lxc options]:lxc options: ' \
-                '-m=-[Memory limit (in bytes)]:limit: ' \
+                '-m[Memory limit (in bytes)]:limit: ' \
                 '--name=-[Container name]:name: ' \
-                '*-p=-[Expose a container'"'"'s port to the host]:port:_ports' \
+                '*-p[Expose a container'"'"'s port to the host]:port:_ports' \
                 '--privileged[Give extended privileges to this container]' \
                 '--rm[Remove intermediate containers when it exits]' \
                 '--sig-proxy[Proxify all received signal]' \
                 '-t[Allocate a pseudo-tty]' \
-                '-u=-[Username or UID]:user:_users' \
-                '*-v=-[Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)]:volume: '\
+                '-u[Username or UID]:user:_users' \
+                '*-v[Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)]:volume: '\
                 '--volumes-from=-[Mount volumes from the specified container]:volume: ' \
-                '-w=-[Working directory inside the container]:directory:_directories' \
+                '-w[Working directory inside the container]:directory:_directories' \
                 '(-):images:__docker_images' \
                 '(-):command: _command_names -e' \
                 '*::arguments: _normal'
@@ -389,7 +389,7 @@ _docker () {
     typeset -A opt_args
 
     _arguments -C \
-      '-H=-[tcp://host:port to bind/connect to]:socket: ' \
+      '-H[tcp://host:port to bind/connect to]:socket: ' \
          '(-): :->command' \
          '(-)*:: :->option-or-argument'
 


### PR DESCRIPTION
Usually short options do not have the form `docker tag -t=image`. So I
changed it to `docker tag -t image`.
