### PR TITLE
Fixed image list for registry with port.

### DIFF
--- a/_docker
+++ b/_docker
@@ -87,7 +87,7 @@ __docker_containers () {
 __docker_images () {
     local expl
     declare -a images
-    images=(${(f)"$(_call_program commands docker images | awk '(NR > 1 && $1 != "<none>"){printf("%s", $1);if ($2 != "<none>") printf("\\:%s", $2); printf("\n")}')"})
+    images=(${(f)"$(_call_program commands docker images | awk '(NR > 1 && $1 != "<none>"){printf("%s", $1);if ($2 != "<none>") printf("\\:%s", $2); printf("\n")}' | sed -e 's/\(\w\):/\1\\:/')"})
     images=($images ${(f)"$(_call_program commands docker images | awk '(NR > 1){printf("%s:%-15s in %s\n", $3,$2,$1)}')"})
     _describe -t docker-images "Images" images
 }
@@ -359,7 +359,7 @@ __docker_subcommand () {
             _arguments ':name:__docker_search'
             ;;
         (push)
-            _arguments ':repository:__docker_repositories_with_tags'
+            _arguments ':images:__docker_images'
             ;;
         (save)
             _arguments \


### PR DESCRIPTION
If you specify a registry like localhost:5000/your-image:latest the auto
completion did not work. 

Also `docker push` does now lookup the image list instead of repositories and tag separately. The image list was fixed, repositories and tags is still not. Also `__docker_repositories_with_tags` returns repository and tag combinations that are not existent which is confusing.
