### PR TITLE
Add redirect option to curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Then reset zsh.
 
 ```sh
 mkdir -p ~/.zsh/completion
-curl https://raw.github.com/felixr/docker-zsh-completion/master/_docker >  ~/.zsh/completion/_docker
+curl -L https://raw.github.com/felixr/docker-zsh-completion/master/_docker >  ~/.zsh/completion/_docker
 exec zsh
 ```
  


### PR DESCRIPTION
Github is redirecting to a different url thereby breaking the instructions
