### PR TITLE
Don't cache bogus subcommands list

### DIFF
--- a/_docker
+++ b/_docker
@@ -391,7 +391,7 @@ __docker_commands() {
         lines=(${(f)"$(_call_program commands docker 2>&1)"})
         _docker_subcommands=(${${${lines[$((${lines[(i)Commands:]} + 1)),${lines[(I)    *]}]}## #}/ ##/:})
         _docker_subcommands=($_docker_subcommands 'daemon:Enable daemon mode' 'help:Show help for a command')
-        _store_cache docker_subcommands _docker_subcommands
+        (( $#_docker_subcommands > 1 )) && _store_cache docker_subcommands _docker_subcommands
     fi
     _describe -t docker-commands "docker command" _docker_subcommands
 }


### PR DESCRIPTION
@esc reports that only the `help` subcommand was completed, until he removed `.zcompcache/docker_subcommands`.  I didn't try to reproduce, but here's a patch to hopefully stop this from recurring.